### PR TITLE
Fixed erroneous octal code

### DIFF
--- a/script/CLIFinder.pl
+++ b/script/CLIFinder.pl
@@ -532,8 +532,8 @@ sub get_half
     if ($line[1] == 73 || $line[1] == 89 || $line[1] == 117 || $line[1] == 69 || $line[1] == 133 || $line[1] == 181 || $line[1] == 153|| $line[1] == 137)
     {
       if ( $Bdir == 0
-              || ($Bdir == 1 && (($line[1] & 064 && $line[1] & 8) || ($line[1] & 128 && $line[1] & 4)))
-              || ($Bdir == 2 && (($line[1] & 128 && $line[1] & 8) || ($line[1] & 064 && $line[1] & 4))) )
+              || ($Bdir == 1 && (($line[1] & 64 && $line[1] & 8) || ($line[1] & 128 && $line[1] & 4)))
+              || ($Bdir == 2 && (($line[1] & 128 && $line[1] & 8) || ($line[1] & 64 && $line[1] & 4))) )
       {
         $cmp++;
         $sequence = $line[9];

--- a/script/CLIFinder.pl
+++ b/script/CLIFinder.pl
@@ -528,8 +528,7 @@ sub get_half
     
     ##looking for flag of the alignment and keep only good reads##
     ##Find if it aligns on R1 or on R2##
-    
-    if ($line[1] == 73 || $line[1] == 89 || $line[1] == 117 || $line[1] == 69 || $line[1] == 133 || $line[1] == 181 || $line[1] == 153|| $line[1] == 137)
+    unless($line[1] & 2 || ($line[1] & 4 && $line[1] & 8))
     {
       if ( $Bdir == 0
               || ($Bdir == 1 && (($line[1] & 64 && $line[1] & 8) || ($line[1] & 128 && $line[1] & 4)))


### PR DESCRIPTION
In Perl, "064" and "64" are not the same thing.
Also made broader test to avoid excluding half-mapped reads.